### PR TITLE
feat: change navbar if clause to includes pathname

### DIFF
--- a/app/src/lib/components/Navbar/Navbar.svelte
+++ b/app/src/lib/components/Navbar/Navbar.svelte
@@ -11,33 +11,33 @@
 <nav class="bg-pp-white border-pp-gray sticky bottom-0 z-10 w-full border-t-1">
 	<ul class="flex justify-evenly py-5">
 		<li>
-			<a class="relative flex-col flex h-full items-center" href={resolve('/store')}>
-				<StoreIcon active={page.url.pathname === '/store'} />
-				{#if page.url.pathname === '/store'}
+			<a class="relative flex-col flex h-full items-center" href={resolve('/store/')}>
+				<StoreIcon active={page.url.pathname.includes('/store')} />
+				{#if page.url.pathname.includes('/store')}
 					<div class="bg-pp-pink absolute -bottom-1 h-1 w-1 rounded-full"></div>
 				{/if}
 			</a>
 		</li>
 		<li>
 			<a class="relative flex h-full flex-col items-center" href={resolve('/home/')}>
-				<HomeIcon active={page.url.pathname === '/home'} />
-				{#if page.url.pathname === '/home'}
+				<HomeIcon active={page.url.pathname.includes('/home')} />
+				{#if page.url.pathname.includes('/home')}
 					<div class="bg-pp-pink absolute -bottom-1 h-1 w-1 rounded-full"></div>
 				{/if}
 			</a>
 		</li>
 		<li>
-			<a class="relative flex-col flex h-full items-center" href={resolve('/messages')}>
-				<MsgIcon active={page.url.pathname === '/messages'} />
-				{#if page.url.pathname === '/messages'}
+			<a class="relative flex-col flex h-full items-center" href={resolve('/messages/')}>
+				<MsgIcon active={page.url.pathname.includes('/messages')} />
+				{#if page.url.pathname.includes('/messages')}
 					<div class="bg-pp-pink absolute -bottom-1 h-1 w-1 rounded-full"></div>
 				{/if}
 			</a>
 		</li>
 		<li>
-			<a class="relative flex-col flex h-full items-center" href={resolve('/profile')}>
-				<ProfileIcon active={page.url.pathname === '/profile'} />
-				{#if page.url.pathname === '/profile'}
+			<a class="relative flex-col flex h-full items-center" href={resolve('/profile/')}>
+				<ProfileIcon active={page.url.pathname.includes('/profile')} />
+				{#if page.url.pathname.includes('/profile')}
 					<div class="bg-pp-pink absolute -bottom-1 h-1 w-1 rounded-full"></div>
 				{/if}
 			</a>


### PR DESCRIPTION
This PR changes the `if` condition to `pathname.includes` to make sure the proper `navbar` section is highlighted in subpages.

## Breaking Changes
None
