### PR TITLE
fix: layout revisions for Chat and Profile pages

### DIFF
--- a/app/src/routes/(pages)/messages/+page.svelte
+++ b/app/src/routes/(pages)/messages/+page.svelte
@@ -8,17 +8,9 @@
 
 <div class="min-h-screen w-full">
 	<div
-		class="from-pp-pink to-pp-light-pink sticky start-0 top-0 z-20 grid w-full grid-cols-3 justify-center bg-linear-to-t p-4 py-8"
+		class="from-pp-pink to-pp-light-pink sticky start-0 top-0 z-20 grid w-full justify-center bg-linear-to-t p-4 py-8"
 	>
-		<div></div>
 		<div class="text-pp-white text-center text-2xl font-semibold">Messages</div>
-
-		<a
-			href={resolve('/messages')}
-			class="text-pp-white top-6 right-6 ml-auto flex items-center gap-2"
-		>
-			<CogSolid class="h-8 w-8" />
-		</a>
 	</div>
 
 	<div class="flex flex-col gap-y-0 px-0 py-0">

--- a/app/src/routes/(pages)/messages/+page.svelte
+++ b/app/src/routes/(pages)/messages/+page.svelte
@@ -1,8 +1,6 @@
 <script>
 	import { resolve } from '$app/paths';
 
-	import { CogSolid } from 'flowbite-svelte-icons';
-
 	import ChatPreview from '$lib/components/Messages/ChatPreview.svelte';
 </script>
 

--- a/app/src/routes/(pages)/messages/chat/+page.svelte
+++ b/app/src/routes/(pages)/messages/chat/+page.svelte
@@ -34,7 +34,7 @@
 	>
 		<a href={resolve('/messages')}>
 			<button
-				class="text-pp-black top-6 left-6 flex items-center gap-2 rounded-full transition active:bg-gray-300"
+				class="text-pp-black top-6 left-6 flex items-center gap-2 rounded-full transition active:text-gray-500"
 			>
 				<ArrowLeftOutline class="h-8 w-8" />
 			</button>
@@ -44,7 +44,7 @@
 
 		<a href={resolve('/messages')}>
 			<button
-				class="text-pp-black top-6 right-6 ml-auto flex items-center gap-2 rounded-full transition active:bg-gray-300"
+				class="text-pp-black top-6 right-6 ml-auto flex items-center gap-2 rounded-full transition active:text-gray-500"
 			>
 				<DotsVerticalOutline class="h-8 w-8" />
 			</button>
@@ -81,7 +81,7 @@
 	<div
 		class="bg-pp-white sticky bottom-0 z-20 grid w-full grid-cols-[auto_1fr_auto] items-center justify-center gap-x-5 p-4 px-6"
 	>
-		<button class="text-pp-gray flex items-center gap-2 rounded-full transition active:bg-gray-300">
+		<button class="text-pp-gray flex items-center gap-2 rounded-full transition active:text-gray-700">
 			<PlusOutline class="h-8 w-8" />
 		</button>
 
@@ -92,7 +92,7 @@
 			class="border-pp-white placeholder-pp-gray focus:border-pp-pink focus:ring-pp-pink w-full rounded-md border px-2 py-2.5"
 			placeholder="Type a message..."
 		/>
-		<button class="text-pp-gray flex items-center gap-2 rounded-full transition active:bg-gray-300">
+		<button class="text-pp-gray flex items-center gap-2 rounded-full transition active:text-gray-700">
 			<FaceGrinOutline class="h-8 w-8" />
 		</button>
 	</div>

--- a/app/src/routes/(pages)/profile/+layout@.svelte
+++ b/app/src/routes/(pages)/profile/+layout@.svelte
@@ -3,7 +3,9 @@
 	const { children } = $props();
 </script>
 
-<div class="bg-pp-white min-h-screen w-full">
-	{@render children()}
-	<Navbar />
+<div class="bg-pp-white h-screen flex flex-col overflow-hidden">
+  <main class="flex-1 overflow-hidden">
+    {@render children()}
+  </main>
+  <Navbar />
 </div>

--- a/app/src/routes/(pages)/profile/+page.svelte
+++ b/app/src/routes/(pages)/profile/+page.svelte
@@ -1,81 +1,94 @@
 <script lang="ts">
 	import {
-		CogSolid,
+		AngleRightOutline,
 		FilePenOutline,
 		CartOutline,
 		HeartOutline,
 		QuestionCircleOutline,
 		BuildingOutline,
-		BookOpenOutline
+		BookOpenOutline,
+		ArrowRightToBracketOutline
 	} from 'flowbite-svelte-icons';
 	import { resolve } from '$app/paths';
 </script>
 
-<div class="from-pp-pink to-pp-light-pink relative min-h-screen w-full bg-linear-to-t p-6">
-	<a
-		href={resolve('/profile')}
-		class="text-pp-white absolute top-6 right-6 flex items-center gap-2"
-	>
-		<CogSolid class="h-8 w-8" />
-	</a>
 
-	<div class="text-pp-white text-center text-2xl font-semibold">Profile</div>
+<div class="relative h-screen overflow-hidden">
+	<div class="from-pp-pink to-pp-light-pink relative h-[36%] bg-gradient-to-t p-6">
+		<div class="text-pp-white text-center text-2xl font-semibold">Profile</div>
+	</div>
 
-	<div class="absolute left-1/2 mt-20 -translate-x-1/2 -translate-y-1/2">
+	<div class="absolute left-1/2 top-[8%] mt-22 -translate-x-1/2 -translate-y-1/2">
 		<div
 			class="flex h-36 w-36 items-center justify-center rounded-full border-4 border-white bg-white shadow-lg"
 		>
 			Karin
 		</div>
-	</div>
-
-	<div class="bg-pp-white mx-auto mt-44 w-80 rounded-xl">
-		<a
-			href={resolve('/profile/edit')}
-			class="block rounded-t-xl px-3 py-4 text-left text-sm font-normal transition hover:bg-gray-100 active:bg-gray-300"
-		>
-			<FilePenOutline class="mr-2 inline-block h-5 w-5" />
-			Edit Profile</a
-		>
-		<div class="border-t-1 border-dotted border-gray-300"></div>
-		<a
-			href="/profile/basket/ordered"
-			class="block px-3 py-4 text-left text-sm font-normal transition hover:bg-gray-100 active:bg-gray-300"
-		>
-			<CartOutline class="mr-2 inline-block h-5 w-5" />
-			View Basket</a
-		>
-		<div class="border-t-1 border-dotted border-gray-300"></div>
-		<a
-			href={resolve('/profile/edit')}
-			class="block px-3 py-4 text-left text-sm font-normal transition hover:bg-gray-100 active:bg-gray-300"
-		>
-			<HeartOutline class="mr-2 inline-block h-5 w-5" />
-			Favorites</a
-		>
-		<div class="border-t-1 border-dotted border-gray-300"></div>
-		<a
-			href={resolve('/profile/edit')}
-			class="block px-3 py-4 text-left text-sm font-normal transition hover:bg-gray-100 active:bg-gray-300"
-		>
-			<QuestionCircleOutline class="mr-2 inline-block h-5 w-5" />
-			Help Center</a
-		>
-		<div class="border-t-1 border-dotted border-gray-300"></div>
-		<a
-			href={resolve('/profile/edit')}
-			class="block px-3 py-4 text-left text-sm font-normal transition hover:bg-gray-100 active:bg-gray-300"
-		>
-			<BuildingOutline class="mr-2 inline-block h-5 w-5" />
-			For Business</a
-		>
-		<div class="border-t-1 border-dotted border-gray-300"></div>
-		<a
-			href={resolve('/profile/edit')}
-			class="block rounded-b-xl px-3 py-4 text-left text-sm font-normal transition hover:bg-gray-100 active:bg-gray-300"
-		>
-			<BookOpenOutline class="mr-2 inline-block h-5 w-5" />
-			Terms and Policies</a
-		>
-	</div>
+		<div class="text-pp-white mt-2 text-center text-lg font-medium">Karin Consebido</div>
+	</div>	
+	<div class="bg-rose-50 h-[64%]"></div>
+	<div class="absolute left-1/2 top-[30%] -translate-x-1/2 bg-pp-white w-80 rounded-xl">
+			<a
+				href={resolve('/profile/edit')}
+				class="block rounded-t-xl px-3 py-4 flex items-center w-full text-base font-normal transition hover:bg-gray-100 active:bg-gray-300"
+			>
+				<FilePenOutline class="ml-2 mr-4 inline-block h-5 w-5" />
+				Edit Profile
+				<AngleRightOutline class="ml-auto mr-1 h-5 w-5" />
+			</a> 
+			<div class="border-t-1 border-dotted border-gray-300"></div>
+			<a
+				href="/profile/basket/ordered"
+				class="block px-3 py-4 flex items-center w-full text-base font-normal transition hover:bg-gray-100 active:bg-gray-300"
+			>
+				<CartOutline class="ml-2 mr-4 inline-block h-5 w-5" />
+				View Basket
+				<AngleRightOutline class="ml-auto mr-1 h-5 w-5" />
+			</a>
+			<div class="border-t-1 border-dotted border-gray-300"></div>
+			<a
+				href={resolve('/profile/edit')}
+				class="block px-3 py-4 flex items-center w-full text-base font-normal transition hover:bg-gray-100 active:bg-gray-300"
+			>
+				<HeartOutline class="ml-2 mr-4 inline-block h-5 w-5" />
+				Favorites
+				<AngleRightOutline class="ml-auto mr-1 h-5 w-5" />
+			</a>
+			<div class="border-t-1 border-dotted border-gray-300"></div>
+			<a
+				href={resolve('/profile/edit')}
+				class="block px-3 py-4 flex items-center w-full text-base font-normal transition hover:bg-gray-100 active:bg-gray-300"
+			>
+				<QuestionCircleOutline class="ml-2 mr-4 inline-block h-5 w-5" />
+				Help Center
+				<AngleRightOutline class="ml-auto mr-1 h-5 w-5" />
+			</a>
+			<div class="border-t-1 border-dotted border-gray-300"></div>
+			<a
+				href={resolve('/profile/edit')}
+				class="block px-3 py-4 flex items-center w-full text-base font-normal transition hover:bg-gray-100 active:bg-gray-300"
+			>
+				<BuildingOutline class="ml-2 mr-4 inline-block h-5 w-5" />
+				For Business
+				<AngleRightOutline class="ml-auto mr-1 h-5 w-5" />
+			</a>
+			<div class="border-t-1 border-dotted border-gray-300"></div>
+			<a
+				href={resolve('/profile/edit')}
+				class="block px-3 py-4 flex items-center w-full text-base font-normal transition hover:bg-gray-100 active:bg-gray-300"
+			>
+				<BookOpenOutline class="ml-2 mr-4 inline-block h-5 w-5" />
+				Terms and Policies
+				<AngleRightOutline class="ml-auto mr-1 h-5 w-5" />
+			</a>
+			<div class="border-t-1 border-dotted border-gray-300"></div>
+			<a
+				href={resolve('/profile/edit')}
+				class="block rounded-b-xl px-3 py-4 text-left text-base font-normal transition hover:bg-gray-100 active:bg-gray-300"
+			>
+				<ArrowRightToBracketOutline class="text-red-800 ml-2 mr-3 inline-block h-5 w-5" />
+				Log Out</a
+			>
+		</div>
 </div>
+

--- a/app/src/routes/(pages)/profile/+page.svelte
+++ b/app/src/routes/(pages)/profile/+page.svelte
@@ -48,42 +48,6 @@
 			<div class="border-t-1 border-dotted border-gray-300"></div>
 			<a
 				href={resolve('/profile/edit')}
-				class="block px-3 py-4 flex items-center w-full text-base font-normal transition hover:bg-gray-100 active:bg-gray-300"
-			>
-				<HeartOutline class="ml-2 mr-4 inline-block h-5 w-5" />
-				Favorites
-				<AngleRightOutline class="ml-auto mr-1 h-5 w-5" />
-			</a>
-			<div class="border-t-1 border-dotted border-gray-300"></div>
-			<a
-				href={resolve('/profile/edit')}
-				class="block px-3 py-4 flex items-center w-full text-base font-normal transition hover:bg-gray-100 active:bg-gray-300"
-			>
-				<QuestionCircleOutline class="ml-2 mr-4 inline-block h-5 w-5" />
-				Help Center
-				<AngleRightOutline class="ml-auto mr-1 h-5 w-5" />
-			</a>
-			<div class="border-t-1 border-dotted border-gray-300"></div>
-			<a
-				href={resolve('/profile/edit')}
-				class="block px-3 py-4 flex items-center w-full text-base font-normal transition hover:bg-gray-100 active:bg-gray-300"
-			>
-				<BuildingOutline class="ml-2 mr-4 inline-block h-5 w-5" />
-				For Business
-				<AngleRightOutline class="ml-auto mr-1 h-5 w-5" />
-			</a>
-			<div class="border-t-1 border-dotted border-gray-300"></div>
-			<a
-				href={resolve('/profile/edit')}
-				class="block px-3 py-4 flex items-center w-full text-base font-normal transition hover:bg-gray-100 active:bg-gray-300"
-			>
-				<BookOpenOutline class="ml-2 mr-4 inline-block h-5 w-5" />
-				Terms and Policies
-				<AngleRightOutline class="ml-auto mr-1 h-5 w-5" />
-			</a>
-			<div class="border-t-1 border-dotted border-gray-300"></div>
-			<a
-				href={resolve('/profile/edit')}
 				class="block rounded-b-xl px-3 py-4 text-left text-base font-normal transition hover:bg-gray-100 active:bg-gray-300"
 			>
 				<ArrowRightToBracketOutline class="text-red-800 ml-2 mr-3 inline-block h-5 w-5" />

--- a/app/src/routes/(pages)/profile/+page.svelte
+++ b/app/src/routes/(pages)/profile/+page.svelte
@@ -15,19 +15,19 @@
 
 <div class="relative h-screen overflow-hidden">
 	<div class="from-pp-pink to-pp-light-pink relative h-[36%] bg-gradient-to-t p-6">
-		<div class="text-pp-white text-center text-2xl font-semibold">Profile</div>
-	</div>
-
-	<div class="absolute left-1/2 top-[8%] mt-22 -translate-x-1/2 -translate-y-1/2">
+		<div class="mt-0 text-pp-white text-center text-2xl font-semibold">Profile</div>
+		<div class="flex flex-col mt-6 items-center justify-center">
 		<div
-			class="flex h-36 w-36 items-center justify-center rounded-full border-4 border-white bg-white shadow-lg"
+			class="flex h-35 w-35 items-center justify-center rounded-full border-4 border-white bg-white shadow-lg"
 		>
 			Karin
 		</div>
 		<div class="text-pp-white mt-2 text-center text-lg font-medium">Karin Consebido</div>
 	</div>	
+	</div>
+
 	<div class="bg-rose-50 h-[64%]"></div>
-	<div class="absolute left-1/2 top-[30%] -translate-x-1/2 bg-pp-white w-80 rounded-xl">
+	<div class="absolute left-1/2 top-[31%] -translate-x-1/2 bg-pp-white w-80 rounded-xl">
 			<a
 				href={resolve('/profile/edit')}
 				class="block rounded-t-xl px-3 py-4 flex items-center w-full text-base font-normal transition hover:bg-gray-100 active:bg-gray-300"

--- a/app/src/routes/(pages)/profile/basket/cancelled/+page.svelte
+++ b/app/src/routes/(pages)/profile/basket/cancelled/+page.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { resolve } from '$app/paths';
 
-	import { ArrowLeftOutline, CogSolid } from 'flowbite-svelte-icons';
+	import { ArrowLeftOutline } from 'flowbite-svelte-icons';
 
 	import Order from '$lib/components/BasketOrders/Order.svelte';
 </script>
@@ -35,7 +35,7 @@
 			>
 			<a
 				href={resolve('/profile/basket/cancelled')}
-				class="border-pp-pink flex flex-1 items-center justify-center border-b-2 transition active:bg-gray-300"
+				class="border-pp-pink flex flex-1 items-center justify-center border-b-2 transition active:text-pp-darker-pink"
 			>
 				<div class="text-pp-pink">Cancelled</div>
 			</a>

--- a/app/src/routes/(pages)/profile/basket/cancelled/+page.svelte
+++ b/app/src/routes/(pages)/profile/basket/cancelled/+page.svelte
@@ -13,7 +13,7 @@
 		>
 			<a href={resolve('/profile')}>
 				<button
-					class="text-pp-white flex items-center gap-2 rounded-full transition active:bg-gray-300"
+					class="text-pp-white flex items-center gap-2 rounded-full transition active:text-pp-darker-pink"
 				>
 					<ArrowLeftOutline class="h-8 w-8" />
 				</button>

--- a/app/src/routes/(pages)/profile/basket/cancelled/+page.svelte
+++ b/app/src/routes/(pages)/profile/basket/cancelled/+page.svelte
@@ -21,12 +21,7 @@
 
 			<div class="text-pp-white text-center text-2xl font-semibold">My Basket</div>
 
-			<a
-				href={resolve('/profile')}
-				class="text-pp-white top-6 right-6 ml-auto flex items-center gap-2"
-			>
-				<CogSolid class="h-8 w-8" />
-			</a>
+			<div></div>
 		</div>
 
 		<div class="bg-pp-white mb-1 flex h-14 w-full">

--- a/app/src/routes/(pages)/profile/basket/completed/+page.svelte
+++ b/app/src/routes/(pages)/profile/basket/completed/+page.svelte
@@ -21,12 +21,7 @@
 
 			<div class="text-pp-white text-center text-2xl font-semibold">My Basket</div>
 
-			<a
-				href={resolve('/profile')}
-				class="text-pp-white top-6 right-6 ml-auto flex items-center gap-2"
-			>
-				<CogSolid class="h-8 w-8" />
-			</a>
+			<div></div>
 		</div>
 
 		<div class="bg-pp-white mb-1 flex h-14 w-full">

--- a/app/src/routes/(pages)/profile/basket/completed/+page.svelte
+++ b/app/src/routes/(pages)/profile/basket/completed/+page.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { resolve } from '$app/paths';
 
-	import { ArrowLeftOutline, CogSolid } from 'flowbite-svelte-icons';
+	import { ArrowLeftOutline } from 'flowbite-svelte-icons';
 
 	import Order from '$lib/components/BasketOrders/Order.svelte';
 </script>
@@ -13,7 +13,7 @@
 		>
 			<a href={resolve('/profile')}>
 				<button
-					class="text-pp-white flex items-center gap-2 rounded-full transition active:bg-gray-300"
+					class="text-pp-white flex items-center gap-2 rounded-full transition active:text-pp-darker-pink"
 				>
 					<ArrowLeftOutline class="h-8 w-8" />
 				</button>

--- a/app/src/routes/(pages)/profile/basket/ordered/+page.svelte
+++ b/app/src/routes/(pages)/profile/basket/ordered/+page.svelte
@@ -21,12 +21,7 @@
 
 			<div class="text-pp-white text-center text-2xl font-semibold">My Basket</div>
 
-			<a
-				href={resolve('/profile')}
-				class="text-pp-white top-6 right-6 ml-auto flex items-center gap-2"
-			>
-				<CogSolid class="h-8 w-8" />
-			</a>
+			<div></div>
 		</div>
 
 		<div class="bg-pp-white sticky top-24 z-20 mb-1 flex h-14 w-full">

--- a/app/src/routes/(pages)/profile/basket/ordered/+page.svelte
+++ b/app/src/routes/(pages)/profile/basket/ordered/+page.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { resolve } from '$app/paths';
 
-	import { ArrowLeftOutline, CogSolid } from 'flowbite-svelte-icons';
+	import { ArrowLeftOutline } from 'flowbite-svelte-icons';
 
 	import Order from '$lib/components/BasketOrders/Order.svelte';
 </script>
@@ -13,7 +13,7 @@
 		>
 			<a href={resolve('/profile')}>
 				<button
-					class="text-pp-white flex items-center gap-2 rounded-full transition active:bg-gray-300"
+					class="text-pp-white flex items-center gap-2 rounded-full transition active:text-pp-darker-pink"
 				>
 					<ArrowLeftOutline class="h-8 w-8" />
 				</button>

--- a/app/src/routes/(pages)/profile/edit/+page.svelte
+++ b/app/src/routes/(pages)/profile/edit/+page.svelte
@@ -129,7 +129,7 @@
 					id="firstname"
 					name="firstname"
 					bind:value={firstname}
-					class="border-pp-gray placeholder-pp-gray w-full rounded-md border px-2 py-2.5 text-xs"
+					class="border-pp-gray placeholder-pp-gray w-full rounded-md border px-2.5 py-2.5 text-xs"
 					placeholder="First Name"
 					required
 				/>
@@ -142,7 +142,7 @@
 					id="lastname"
 					name="lastname"
 					bind:value={lastname}
-					class="border-pp-gray placeholder-pp-gray w-full rounded-md border px-3 py-2.5 text-xs"
+					class="border-pp-gray placeholder-pp-gray w-full rounded-md border px-2.5 py-2.5 text-xs"
 					placeholder="Last Name"
 					required
 				/>
@@ -155,7 +155,7 @@
 					id="phone"
 					name="phone"
 					bind:value={phone}
-					class="border-pp-gray placeholder-pp-gray w-full rounded-md border px-3 py-2.5 text-xs"
+					class="border-pp-gray placeholder-pp-gray w-full rounded-md border px-2.5 py-2.5 text-xs"
 					placeholder="+63 912 345 6789"
 					required
 				/>

--- a/app/src/routes/(pages)/profile/edit/+page.svelte
+++ b/app/src/routes/(pages)/profile/edit/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ArrowLeftOutline, CogSolid } from 'flowbite-svelte-icons';
+	import { ArrowLeftOutline, EditOutline } from 'flowbite-svelte-icons';
 	import { resolve } from '$app/paths';
 	import { enhance } from '$app/forms';
 	import { invalidateAll } from '$app/navigation';
@@ -48,127 +48,129 @@
 	}
 </script>
 
-<div class="from-pp-pink to-pp-light-pink relative min-h-screen w-full bg-linear-to-t p-6">
-	{#if showToast}
-		<Toast color={isSuccess ? 'green' : 'red'} class="fixed top-4 right-4 z-50">
-			{toastMessage}
-		</Toast>
-	{/if}
+<div class="relative h-screen overflow-hidden">
+	<div class="from-pp-pink to-pp-light-pink relative h-[17.5%] bg-gradient-to-t p-6">
+		{#if showToast}
+			<Toast color={isSuccess ? 'green' : 'red'} class="fixed top-4 right-4 z-50">
+				{toastMessage}
+			</Toast>
+		{/if}
 
-	<a href={resolve('/profile')} class="text-pp-white absolute top-6 left-6 flex items-center gap-1">
-		<ArrowLeftOutline class="h-8 w-8" />
-	</a>
+		<a href={resolve('/profile')} class="text-pp-white absolute top-6 left-6 flex items-center gap-1 transition active:text-pp-darker-pink">
+			<ArrowLeftOutline class="h-8 w-8" />
+		</a>
 
-	<div class="text-pp-white text-center text-2xl font-semibold">Edit Profile</div>
+		<div class="text-pp-white text-center text-2xl font-semibold">Edit Profile</div>
 
-	<a
-		href={resolve('/profile')}
-		class="text-pp-white absolute top-6 right-6 flex items-center gap-2"
-	>
-		<CogSolid class="h-8 w-8" />
-	</a>
-
-	<form
-		method="POST"
-		enctype="multipart/form-data"
-		bind:this={form}
-		use:enhance={() => {
-			isSaving = true;
-			return async ({ result, update }) => {
-				if (result.type === 'success') {
-					const formData = result.data as { success?: boolean; message?: string } | undefined;
-					if (formData?.success) {
+		<form
+			method="POST"
+			enctype="multipart/form-data"
+			bind:this={form}
+			use:enhance={() => {
+				isSaving = true;
+				return async ({ result, update }) => {
+					if (result.type === 'success') {
+						const formData = result.data as { success?: boolean; message?: string } | undefined;
+						if (formData?.success) {
+							toastMessage = 'Profile updated successfully!';
+							isSuccess = true;
+						} else {
+							toastMessage = formData?.message || 'Update failed';
+							isSuccess = false;
+						}
+					} else if (result.type === 'failure') {
+						const errorData = result.data as { message?: string } | undefined;
+						toastMessage = errorData?.message || 'An error occurred';
+						isSuccess = false;
+					} else {
 						toastMessage = 'Profile updated successfully!';
 						isSuccess = true;
-					} else {
-						toastMessage = formData?.message || 'Update failed';
-						isSuccess = false;
 					}
-				} else if (result.type === 'failure') {
-					const errorData = result.data as { message?: string } | undefined;
-					toastMessage = errorData?.message || 'An error occurred';
-					isSuccess = false;
-				} else {
-					toastMessage = 'Profile updated successfully!';
-					isSuccess = true;
-				}
-				await update({ reset: false });
-				isSaving = false;
-				showToast = true;
-				setTimeout(() => (showToast = false), 2000);
-				await invalidateAll();
-			};
-		}}
-	>
-		<div class="mt-13 flex flex-col items-center">
-			<button type="button" onclick={handleImageClick} class="focus:outline-none">
+					await update({ reset: false });
+					isSaving = false;
+					showToast = true;
+					setTimeout(() => (showToast = false), 2000);
+					await invalidateAll();
+				};
+			}}
+		>
+			<div class="mt-8 flex flex-col items-center">
 				<div
-					class="flex h-36 w-36 items-center justify-center rounded-full border-4 border-white bg-white shadow-lg"
+					class="flex h-36 w-36 items-center justify-center rounded-full border-4 border-white bg-white"
 				>
 					<img src={imgUrl} alt="Profile" class="h-full w-full rounded-full object-cover" />
 				</div>
-			</button>
-			<input
-				type="file"
-				accept="image/*"
-				bind:this={fileInput}
-				onchange={handleFileChange}
-				class="hidden"
-				name="profile_image"
-			/>
-		</div>
-
-		<div class="bg-pp-white mx-auto mt-10 w-80 rounded-xl">
-			<div class="mb-1 grid gap-2 px-3 pt-2">
-				<div>
-					<label for="firstname" class="text-pp-gray mb-2.5 text-xs font-medium">First Name</label>
-					<input
-						type="text"
-						id="firstname"
-						name="firstname"
-						bind:value={firstname}
-						class="border-pp-gray placeholder-pp-gray w-full rounded-md border px-2 py-2.5 text-xs"
-						placeholder="First Name"
-						required
-					/>
-				</div>
-
-				<div>
-					<label for="lastname" class="text-pp-gray mb-2.5 text-xs font-medium">Last Name</label>
-					<input
-						type="text"
-						id="lastname"
-						name="lastname"
-						bind:value={lastname}
-						class="border-pp-gray placeholder-pp-gray w-full rounded-md border px-3 py-2.5 text-xs"
-						placeholder="Last Name"
-						required
-					/>
-				</div>
-
-				<div>
-					<label for="phone" class="text-pp-gray mb-2.5 text-xs font-medium">Phone Number</label>
-					<input
-						type="tel"
-						id="phone"
-						name="phone"
-						bind:value={phone}
-						class="border-pp-gray placeholder-pp-gray w-full rounded-md border px-3 py-2.5 text-xs"
-						placeholder="+63 912 345 6789"
-						required
-					/>
-				</div>
-			</div>
-
-			<div class="pt-4 pr-6 pb-12">
-				<button
-					type="submit"
-					class="bg-pp-pink text-pp-white hover:bg-pp-darker-pink float-right rounded px-4 py-1 text-xs"
-					disabled={isSaving}
-				>
-					{isSaving ? 'Saving...' : 'Save changes'}
+				<input
+					type="file"
+					accept="image/*"
+					bind:this={fileInput}
+					onchange={handleFileChange}
+					class="hidden"
+					name="profile_image"
+				/>
+				<button type="button" onclick={handleImageClick} class="focus:outline-none">				
+					<div 
+						class="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-400
+								-translate-y-9 translate-x-12 active:bg-emerald-500"
+					>
+						<EditOutline class="absolute left-2.5 h-6 w-6 text-white" />
+					</div>
 				</button>
 			</div>
+		</form>
+	</div>
+	
+	<div class="absolute left-1/2 top-[23%] -translate-x-1/2 mx-auto mt-10 w-84">
+		<div class="mb-1 grid gap-2.5 px-3 pt-2">
+			<div>
+				<label for="firstname" class="text-pp-gray mb-2.5 text-sm font-medium">First Name</label>
+				<input
+					type="text"
+					id="firstname"
+					name="firstname"
+					bind:value={firstname}
+					class="border-pp-gray placeholder-pp-gray w-full rounded-md border px-2 py-2.5 text-xs"
+					placeholder="First Name"
+					required
+				/>
+			</div>
+
+			<div>
+				<label for="lastname" class="text-pp-gray mb-2.5 text-sm font-medium">Last Name</label>
+				<input
+					type="text"
+					id="lastname"
+					name="lastname"
+					bind:value={lastname}
+					class="border-pp-gray placeholder-pp-gray w-full rounded-md border px-3 py-2.5 text-xs"
+					placeholder="Last Name"
+					required
+				/>
+			</div>
+
+			<div>
+				<label for="phone" class="text-pp-gray mb-2.5 text-sm font-medium">Phone Number</label>
+				<input
+					type="tel"
+					id="phone"
+					name="phone"
+					bind:value={phone}
+					class="border-pp-gray placeholder-pp-gray w-full rounded-md border px-3 py-2.5 text-xs"
+					placeholder="+63 912 345 6789"
+					required
+				/>
+			</div>
 		</div>
-	</form>
+
+		<div class="pt-4 pr-6 pb-12">
+			<button
+				type="submit"
+				class="bg-pp-pink text-pp-white active:bg-pp-darker-pink float-right rounded-lg px-4 py-1 text-xs"
+				disabled={isSaving}
+			>
+				{isSaving ? 'Saving...' : 'Save changes'}
+			</button>
+		</div>
+	</div>
+	
 </div>


### PR DESCRIPTION
LOTS OF FRONTEND CHANGES
- Working edit profile picture button, clicking pic does nothing now
- Edit Profile page layout should reflect the Figma prototype layout more closely
- Removal of Settings icons in Chat, Profile pages
- Log out tab in Profile page
- Different behavior of buttons on click (small revision, just for color and how the elements are highlighted)
- Forgot to run formatters my bad